### PR TITLE
change whisper storage retention policy

### DIFF
--- a/files/storage-schemas.conf
+++ b/files/storage-schemas.conf
@@ -1,5 +1,13 @@
 [default]
 pattern = .*
+retentions = 1m:31d,5m:1y
+
+[collectd]
+pattern = ^collectd.*
+retentions = 1m:7d,5m:180d
+
+[performance]
+pattern = ^performance.*
 retentions = 1m:1y
 
 [stats]


### PR DESCRIPTION
Whisper by default creates around 6Mb file for every whisper database
and by changing the storage retention policy to lower frequency, we save
some space.
